### PR TITLE
Exclude test/bench content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/GoogleChromeLabs/wasmbin"
 categories = ["wasm", "parser-implementations"]
 keywords = ["webassembly", "wasm", "parser", "serializer"]
 
+exclude = [
+    "tests/testsuite",
+    "benches/fixture.wasm",
+]
+
 [dependencies]
 leb128 = "0.2.4"
 thiserror = "1.0.9"


### PR DESCRIPTION
The testsuite submodule and benches/fixture.wasm file bloat the size of the compressed crate tarball to be 5.7MiB, and the unpacked crate to 30MiB, removing them from the publish crate reduces the compressed crate tarball to 32KiB and the unpacked crate to 232KiB.