### PR TITLE
Add custom sections for debug info

### DIFF
--- a/src/sections.rs
+++ b/src/sections.rs
@@ -90,11 +90,6 @@ pub struct ProducerVersionedName {
     pub version: String,
 }
 
-#[derive(Wasmbin, WasmbinCountable, Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
-pub struct ExternalUrlSection {
-    pub url_name: String,
-}
-
 #[derive(Wasmbin, CustomDebug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
 pub struct RawCustomSection {
     pub name: String,
@@ -148,9 +143,9 @@ define_custom_sections! {
     Name(Vec<NameSubSection>) = "name",
     Producers(Vec<ProducerField>) = "producers",
     // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
-    ExternalDebugInfo(ExternalUrlSection) = "external_debug_info",
+    ExternalDebugInfo(String) = "external_debug_info",
     // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#source-maps
-    SourceMappingUrl(ExternalUrlSection) = "sourceMappingURL",
+    SourceMappingUrl(String) = "sourceMappingURL",
 }
 
 #[wasmbin_discriminants]

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -90,6 +90,11 @@ pub struct ProducerVersionedName {
     pub version: String,
 }
 
+#[derive(Wasmbin, WasmbinCountable, Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
+pub struct ExternalUrlSection {
+    pub url_name: String,
+}
+
 #[derive(Wasmbin, CustomDebug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
 pub struct RawCustomSection {
     pub name: String,
@@ -142,6 +147,10 @@ macro_rules! define_custom_sections {
 define_custom_sections! {
     Name(Vec<NameSubSection>) = "name",
     Producers(Vec<ProducerField>) = "producers",
+    // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
+    ExternalDebugInfo(ExternalUrlSection) = "external_debug_info",
+    // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#source-maps
+    SourceMappingUrl(ExternalUrlSection) = "sourceMappingURL",
 }
 
 #[wasmbin_discriminants]


### PR DESCRIPTION
From: https://github.com/GoogleChromeLabs/wasmbin/issues/6

~~I haven't tested this out yet - I'll come back to it shortly - but I believe this is what we want.~~

Tested this out locally, by comparing with how emscripten adds this field.

```
% emcc -gseparate-dwarf=foobar hello-world.cc -o test.wasm
% wasm-objdump -j external_debug_info -s test.wasm

test.wasm:	file format wasm 0x1

Contents of section Custom:
0050c3c: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0050c4c: 696e 666f 0666 6f6f 6261 72              info.foobar
```

Matches the hex code by adding a section using the wasmbin API.
```
        module
            .sections
            .push(Section::Custom(Blob::from(CustomSection::ExternalDebugInfo(
                "foobar".to_string().into()
            ))));
```

```
0957a13: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0957a23: 696e 666f 0666 6f6f 6261 72              info.foobar
```