### PR TITLE
Make it possible to use macros/attributes outside of the wasmbin

### DIFF
--- a/src/builtins/blob.rs
+++ b/src/builtins/blob.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::builtins::{Lazy, WasmbinCountable};
-use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode};
-use crate::visit::Visit;
+use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode, PathItem};
+use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 
 #[derive(Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]

--- a/src/builtins/boolean.rs
+++ b/src/builtins/boolean.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::DecodeErrorKind;
+use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode};
 use crate::visit::Visit;
 
 encode_decode_as!(bool, {

--- a/src/builtins/collections.rs
+++ b/src/builtins/collections.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::io::{Decode, DecodeError, Encode, PathItem};
+use crate::visit::{Visit, VisitError};
 
 pub use wasmbin_derive::WasmbinCountable;
 pub trait WasmbinCountable {}

--- a/src/builtins/floats.rs
+++ b/src/builtins/floats.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::{Decode, DecodeError, Encode, Wasmbin};
-use crate::visit::Visit;
+use crate::io::{Decode, DecodeError, Encode, PathItem, Wasmbin};
+use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 
 /// A wrapper around floats that treats `NaN`s as equal.

--- a/src/indices.rs
+++ b/src/indices.rs
@@ -17,7 +17,8 @@ use crate::io::{Decode, DecodeError, Encode, PathItem, Wasmbin};
 use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 
-macro_rules! newtype_id {
+#[macro_export]
+macro_rules! new_type_id {
     ($name:ident) => {
         #[derive(PartialEq, Eq, Clone, Copy, Wasmbin, WasmbinCountable, Arbitrary, Hash, Visit)]
         #[repr(transparent)]
@@ -50,12 +51,12 @@ macro_rules! newtype_id {
     };
 }
 
-newtype_id!(DataId);
-newtype_id!(ElemId);
-newtype_id!(FuncId);
-newtype_id!(GlobalId);
-newtype_id!(LabelId);
-newtype_id!(LocalId);
-newtype_id!(MemId);
-newtype_id!(TableId);
-newtype_id!(TypeId);
+new_type_id!(DataId);
+new_type_id!(ElemId);
+new_type_id!(FuncId);
+new_type_id!(GlobalId);
+new_type_id!(LabelId);
+new_type_id!(LocalId);
+new_type_id!(MemId);
+new_type_id!(TableId);
+new_type_id!(TypeId);

--- a/src/indices.rs
+++ b/src/indices.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::builtins::WasmbinCountable;
-use crate::io::Wasmbin;
-use crate::visit::Visit;
+use crate::io::{Decode, DecodeError, Encode, PathItem, Wasmbin};
+use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 
 macro_rules! newtype_id {

--- a/src/instructions/misc.rs
+++ b/src/instructions/misc.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::indices::{DataId, ElemId, MemId, TableId};
-use crate::io::Wasmbin;
-use crate::visit::Visit;
+use crate::io::{Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin};
+use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 
 #[crate::wasmbin_discriminants]

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -16,7 +16,7 @@ use crate::builtins::FloatConst;
 use crate::indices::{FuncId, GlobalId, LabelId, LocalId, MemId, TableId, TypeId};
 use crate::io::{Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin};
 use crate::types::{BlockType, RefType, ValueType};
-use crate::visit::Visit;
+use crate::visit::{Visit, VisitError};
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;
 use thiserror::Error;

--- a/src/instructions/simd.rs
+++ b/src/instructions/simd.rs
@@ -14,7 +14,7 @@
 
 use super::MemArg;
 use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode, Wasmbin};
-use crate::visit::Visit;
+use crate::visit::{Visit, VisitError};
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;
 

--- a/src/instructions/threads.rs
+++ b/src/instructions/threads.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use super::MemArg;
-use crate::io::{DecodeErrorKind, Wasmbin};
+use crate::io::{
+    Decode, DecodeError, DecodeErrorKind, DecodeWithDiscriminant, Encode, PathItem, Wasmbin,
+};
 use crate::visit::Visit;
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,7 +44,7 @@ pub enum DecodeErrorKind {
 }
 
 #[derive(Debug)]
-pub(crate) enum PathItem {
+pub enum PathItem {
     Name(&'static str),
     Index(usize),
     Variant(&'static str),
@@ -58,7 +58,7 @@ pub struct DecodeError {
 }
 
 impl DecodeError {
-    pub(crate) fn in_path(mut self, item: PathItem) -> Self {
+    pub fn in_path(mut self, item: PathItem) -> Self {
         self.path.push(item);
         self
     }
@@ -111,7 +111,7 @@ macro_rules! encode_decode_as {
     ($ty:ty, {
         $($lhs:tt <=> $rhs:tt,)*
     } $(, |$other:pat| $other_handler:expr)?) => {
-        impl crate::io::Encode for $ty {
+        impl Encode for $ty {
             #[allow(unused_parens)]
             fn encode(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
                 match *self {
@@ -120,10 +120,10 @@ macro_rules! encode_decode_as {
             }
         }
 
-        impl crate::io::Decode for $ty {
+        impl Decode for $ty {
             #[allow(unused_parens)]
-            fn decode(r: &mut impl std::io::Read) -> Result<Self, crate::io::DecodeError> {
-                Ok(match crate::io::Decode::decode(r)? {
+            fn decode(r: &mut impl std::io::Read) -> Result<Self, DecodeError> {
+                Ok(match Decode::decode(r)? {
                     $($rhs => $lhs,)*
                     $($other => return $other_handler)?
                 })

--- a/src/module.rs
+++ b/src/module.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::builtins::Blob;
-use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode, Wasmbin};
+use crate::io::{Decode, DecodeError, DecodeErrorKind, Encode, PathItem, Wasmbin};
 use crate::sections::{Section, StdPayload};
-use crate::visit::Visit;
+use crate::visit::{Visit, VisitError};
 use arbitrary::Arbitrary;
 use std::cmp::Ordering;
 

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -17,11 +17,9 @@ use crate::builtins::WasmbinCountable;
 use crate::builtins::{Blob, RawBlob};
 use crate::indices::{FuncId, GlobalId, LocalId, MemId, TableId, TypeId};
 use crate::instructions::Expression;
-use crate::io::{
-    Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin,
-};
+use crate::io::{Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin};
 use crate::types::{FuncType, GlobalType, MemType, RefType, TableType, ValueType};
-use crate::visit::Visit;
+use crate::visit::{Visit, VisitError};
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;
 use custom_debug::Debug as CustomDebug;

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@
 use crate::builtins::WasmbinCountable;
 use crate::indices::TypeId;
 use crate::io::{Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin};
-use crate::visit::Visit;
+use crate::visit::{Visit, VisitError};
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;
 use std::convert::TryFrom;

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -40,7 +40,7 @@ impl<E: std::fmt::Debug> std::fmt::Debug for VisitError<E> {
 impl<E: std::error::Error> std::error::Error for VisitError<E> {}
 
 impl<E> VisitError<E> {
-    pub(crate) fn in_path(self, item: PathItem) -> Self {
+    pub fn in_path(self, item: PathItem) -> Self {
         #[allow(clippy::match_wildcard_for_single_variants)]
         match self {
             VisitError::LazyDecode(err) => VisitError::LazyDecode(err.in_path(item)),
@@ -152,13 +152,13 @@ pub trait Visit: 'static + Sized {
 
 macro_rules! impl_visit_for_iter {
     ($ty:tt $(<$param:ident>)?) => {
-        impl$(<$param: crate::visit::Visit>)? crate::visit::Visit for $ty $(<$param>)? {
+        impl$(<$param: Visit>)? Visit for $ty $(<$param>)? {
             fn visit_children<'a, VisitT: 'static, E, F: FnMut(&'a VisitT) -> Result<(), E>>(
                 &'a self,
                 f: &mut F,
-            ) -> Result<(), crate::visit::VisitError<E>> {
+            ) -> Result<(), VisitError<E>> {
                 for (i, v) in self.iter().enumerate() {
-                    v.visit_child(f).map_err(move |err| err.in_path(crate::io::PathItem::Index(i)))?;
+                    v.visit_child(f).map_err(move |err| err.in_path(PathItem::Index(i)))?;
                 }
                 Ok(())
             }
@@ -166,9 +166,9 @@ macro_rules! impl_visit_for_iter {
             fn visit_children_mut<VisitT: 'static, E, F: FnMut(&mut VisitT) -> Result<(), E>>(
                 &mut self,
                 f: &mut F,
-            ) -> Result<(), crate::visit::VisitError<E>> {
+            ) -> Result<(), VisitError<E>> {
                 for (i, v) in self.iter_mut().enumerate() {
-                    v.visit_child_mut(f).map_err(move |err| err.in_path(crate::io::PathItem::Index(i)))?;
+                    v.visit_child_mut(f).map_err(move |err| err.in_path(PathItem::Index(i)))?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
I'm using wasmbin for my own project and trying to its attributes to declare data structures to use them in wasm custom sections.
It appears that some proc_macro's have **crate::** in their **use** declarations and that's blocking me from using them in my project.
This PR make it usable outside of wasmbin too.