### PR TITLE
Exceptions: import and export section

### DIFF
--- a/src/indices.rs
+++ b/src/indices.rs
@@ -52,6 +52,7 @@ macro_rules! newtype_id {
 
 newtype_id!(DataId);
 newtype_id!(ElemId);
+newtype_id!(ExceptionId);
 newtype_id!(FuncId);
 newtype_id!(GlobalId);
 newtype_id!(LabelId);

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -15,12 +15,10 @@
 use crate::builtins::Lazy;
 use crate::builtins::WasmbinCountable;
 use crate::builtins::{Blob, RawBlob};
-use crate::indices::{FuncId, GlobalId, LocalId, MemId, TableId, TypeId};
+use crate::indices::{ExceptionId, FuncId, GlobalId, LocalId, MemId, TableId, TypeId};
 use crate::instructions::Expression;
-use crate::io::{
-    Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin,
-};
-use crate::types::{FuncType, GlobalType, MemType, RefType, TableType, ValueType};
+use crate::io::{Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin};
+use crate::types::{ExceptionType, FuncType, GlobalType, MemType, RefType, TableType, ValueType};
 use crate::visit::Visit;
 use crate::wasmbin_discriminants;
 use arbitrary::Arbitrary;
@@ -156,6 +154,7 @@ pub enum ImportDesc {
     Table(TableType) = 0x01,
     Mem(MemType) = 0x02,
     Global(GlobalType) = 0x03,
+    Exception(ExceptionType) = 0x04,
 }
 
 #[derive(Wasmbin, Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
@@ -184,6 +183,7 @@ pub enum ExportDesc {
     Table(TableId) = 0x01,
     Mem(MemId) = 0x02,
     Global(GlobalId) = 0x03,
+    Exception(ExceptionId) = 0x04,
 }
 
 #[derive(Wasmbin, WasmbinCountable, Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,3 +183,9 @@ pub struct GlobalType {
     pub value_type: ValueType,
     pub mutable: bool,
 }
+
+#[derive(Wasmbin, WasmbinCountable, Debug, Arbitrary, PartialEq, Eq, Hash, Clone, Visit)]
+#[wasmbin(discriminant = 0x00)]
+pub struct ExceptionType {
+    pub func_type: FuncType,
+}


### PR DESCRIPTION
This follows more of the spec here: https://webassembly.github.io/exception-handling/core/binary/modules.html
Follow up to https://github.com/GoogleChromeLabs/wasmbin/pull/9

Testing:

After building with `-fwasm-exceptions -Wl,--export=__cpp_exception` using emscripten, and then running the dump example:

```
% ./target/release/examples/dump a.out.wasm export
...
            Export {
                name: "__cpp_exception",
                desc: Exception(
                    Exception#0,
                ),
            },
```

PTAL @RReverser 
